### PR TITLE
related course 

### DIFF
--- a/src/pages/user/fullCourseDetails/FullCouseDetalsPage.tsx
+++ b/src/pages/user/fullCourseDetails/FullCouseDetalsPage.tsx
@@ -21,6 +21,7 @@ import {
     useRemoveFromWishlistMutation,
 } from "../wishlist/wishlistApiSlice";
 import Reviews from "./Reviews";
+import MoreCourses from "./MoreCourses";
 
 export interface IChapter {
     chapterTitle: string;
@@ -48,7 +49,7 @@ interface IFullCourseData {
     prerequisites: string[];
     demoVideos: string;
     chapters: IChapter[];
-    category: string;
+    category?: string;
     estimatedPrice: number;
     level: string;
     price: number;
@@ -401,6 +402,12 @@ const FullCouseDetalsPage = () => {
 
                 <div className="w-9/12 mx-auto rounded-base mt-10">
                     <Reviews courseId={id as string} />
+                </div>
+                <div className="w-9/12 mx-auto rounded-base mt-10">
+                    <MoreCourses
+                        category={fullCourseData?.category}
+                        currentCourseId={fullCourseData._id}
+                    />
                 </div>
             </div>
         </div>

--- a/src/pages/user/fullCourseDetails/MoreCourses.tsx
+++ b/src/pages/user/fullCourseDetails/MoreCourses.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { useGetCoursesCardDetailsQuery } from "../explore/exploreApiSlice";
+import CourseCardLong from "../explore/CourseCardLong";
+import { ICourse } from "../explore/ExplorePage";
+import { Link } from "react-router-dom";
+
+const MoreCourses: React.FC<{ category?: string; currentCourseId: string }> = ({
+    category,
+    currentCourseId,
+}) => {
+    const { data } = useGetCoursesCardDetailsQuery({ category: category });
+
+    if (data && data.length <= 1) return null;
+
+    return (
+        <div className="bg-zinc-100 px-6 py-6 border border-black rounded-base">
+            <h3 className=" w-fit px-2 rounded-base font-publicSans font-semibold">
+                You might also like
+            </h3>
+            <div className="mt-2">
+                {data &&
+                    data.courses.map((courseDetails: ICourse) => {
+                        if (courseDetails._id === currentCourseId) return null; // resusing explore page api, will contrain duplicate of same course
+                        return (
+                            <Link
+                                to={`/explore/course/${courseDetails._id}`}
+                                key={courseDetails._id}
+                                onClick={() =>
+                                    window.scrollTo({
+                                        top: 0,
+                                        behavior: "instant",
+                                    })
+                                }
+                            >
+                                <CourseCardLong courseDetails={courseDetails} />
+                            </Link>
+                        );
+                    })}
+            </div>
+        </div>
+    );
+};
+
+export default MoreCourses;


### PR DESCRIPTION
This pull request includes changes to the `FullCouseDetalsPage` to add a new component for displaying related courses and modifies the course data interface to make the category field optional. Additionally, a new component `MoreCourses` has been introduced to fetch and display related courses.

### Changes to `FullCouseDetalsPage`:

* Added import for `MoreCourses` component.
* Modified `IFullCourseData` interface to make the `category` field optional.
* Added a new section to render the `MoreCourses` component, passing the current course's category and ID as props.

### New `MoreCourses` component:

* Created `MoreCourses` component to fetch and display related courses based on the current course's category, excluding the current course itself.